### PR TITLE
Ignore pak files and common OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+compiled/
+*.pak
+
+# Linux
+*~
+# MacOS
+.DS_Store
+# Windows
+[dD]esktop.ini


### PR DESCRIPTION
This will prevent `pak` files from being listed by git status and so reduce the chance of committing a pak file.