### PR TITLE
Separate build process for addons and standard pakset

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -50,19 +50,19 @@ jobs:
         overwrite: true
 
   compile_pak192.comic-addons:
-    runs-ons: ubuntu-latest
+    runs-on: ubuntu-latest
 
-        steps:
+    steps:
     - uses: actions/checkout@v1
 
     - name: install_dependencies
       run: |
-        sudo apt-get -y update
-        sudo apt-get -ym install libpng-dev
-        sudo apt-get -ym install libsdl2-dev
-        sudo apt-get -ym install libbz2-dev
-        sudo apt-get -ym install autoconf
-        svn checkout svn://servers.simutrans.org/simutrans simutrans
+          sudo apt-get -y update
+          sudo apt-get -ym install libpng-dev
+          sudo apt-get -ym install libsdl2-dev
+          sudo apt-get -ym install libbz2-dev
+          sudo apt-get -ym install autoconf
+          svn checkout svn://servers.simutrans.org/simutrans simutrans
     - name: setup
       run: |
         cd simutrans/trunk

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -3,7 +3,7 @@ name: Nightly build Ubuntu
 on: [push]
 
 jobs:
-  build:
+  compile_pak192.comic:
 
     runs-on: ubuntu-latest
    
@@ -48,14 +48,42 @@ jobs:
         asset_name: pak192-nightly.zip
         tag: Nightly
         overwrite: true
-        
-    - name: make pak192 addons
+
+  compile_pak192.comic-addons:
+    runs-ons: ubuntu-latest
+
+        steps:
+    - uses: actions/checkout@v1
+
+    - name: install_dependencies
       run: |
-        bash COMPILE_ADDON.sh
-    - name: Rename result
+        sudo apt-get -y update
+        sudo apt-get -ym install libpng-dev
+        sudo apt-get -ym install libsdl2-dev
+        sudo apt-get -ym install libbz2-dev
+        sudo apt-get -ym install autoconf
+        svn checkout svn://servers.simutrans.org/simutrans simutrans
+    - name: setup
+      run: |
+        cd simutrans/trunk
+        autoconf
+        ./configure
+        cat config.default >>/dev/stderr
+    - name: make makeobj
+      run: |
+          cd simutrans/trunk/makeobj
+          make
+          mv makeobj ../../..
+          cd ../../..
+          rm -rf simutrans
+
+    - name: Compile pak192.comic addons
+      run: bash COMPILE_ADDON.sh
+
+    - name: zip addons
       run: |
         mv compiled_addons pak192.comic-nightly-addons
-        zip -r pak192-nightly-addons.zip pak192.comic-nightly-addons
+        zip -r pak192.comic-nightly-addons.zip pak192.comic-nightly-addons
 
     - name: Update binaries of Nightly Release
       uses: svenstaro/upload-release-action@v1-release

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -3,7 +3,7 @@ name: Nightly build Ubuntu
 on: [push]
 
 jobs:
-  compile_pak192.comic:
+  compile_pak192-comic:
 
     runs-on: ubuntu-latest
    
@@ -49,7 +49,7 @@ jobs:
         tag: Nightly
         overwrite: true
 
-  compile_pak192.comic-addons:
+  compile_pak192-comic-addons:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -83,7 +83,7 @@ jobs:
     - name: zip addons
       run: |
         mv compiled_addons pak192.comic-nightly-addons
-        zip -r pak192.comic-nightly-addons.zip pak192.comic-nightly-addons
+        zip -r pak192-nightly-addons.zip pak192.comic-nightly-addons
 
     - name: Update binaries of Nightly Release
       uses: svenstaro/upload-release-action@v1-release


### PR DESCRIPTION
- Addons and standard assets will be executed pararel instead of serial.
- Minimize the build errors when the one of build jobs het failed.

Currently working:
- [ ] Separate addons and standard job build
- [ ] Set extended version to be compiled whenever the extended branch get compiled.